### PR TITLE
correct values for 'label' field and total for 'N'-labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ We used 761 regular expression patterns to collect candidate repositories contai
 
 ### Overview of SecretBench Metadata:
 
-We curated 818 public Github repositories and extracted 97,479 candidate secrets. Out of 97,479 secrets, we labeled 15,084 secrets as true secrets. Each secret is manually labeled by finding out whether the secret is actual or not after inspecting the secret and the source code context of the secret. Below we present an overview of the SecretBench data.
+We curated 818 public Github repositories and extracted 97,479 candidate secrets. Out of 97,479 secrets, we labeled 15,086 secrets as true secrets. Each secret is manually labeled by finding out whether the secret is actual or not after inspecting the secret and the source code context of the secret. Below we present an overview of the SecretBench data.
 
 |Field Name|Description|Data Type|
 |--------|--------|--------|
@@ -73,7 +73,7 @@ We curated 818 public Github repositories and extracted 97,479 candidate secrets
 |end_column|End index of the secret in the end line.|Integer|
 |committer_email|Email address of the developer who committed the secret.|String|
 |commit_date|The timestamp of the commit. For example: 2018-10-24T21:22:19Z|TimeStamp|
-|label|The ground truth label of the secret. "True" for actual secret and "False" for fake/dummy secret.|Boolean|
+|label|The ground truth label of the secret. "Y" for actual secret and "N" for fake/dummy secret.|Boolean|
 |is_template|Flag to indicate if the secret is a placeholder such as "MY_PASSWORD" and "Place_Your_Token_Here". | Boolean|
 |in_url| Flag to indicate if the secret is part of URL such as "http://user:pwd@site.com".| Boolean|
 |entropy| Shannon entropy value of the secret.| Float|


### PR DESCRIPTION
After loading the `secrebench.csv` in R (`sb <- read_csv("secretbench.csv")`), I'm seeing the following stats on the `label` column:
```R
> table(sb$label)

    N     Y 
82393 15086 
```
The total `82393+15086=97479` is the same as in the README, but the number of "fake/dummy" secrets is, I believe, off by 2.  Also, README says that the values for the `label` column are `True` and `False` whereas the dataset contains `Y` and `N`.

Double-checking with a short Python program:
```python
#!/usr/bin/env python3

import csv

cnts = {}
with open('secretbench.csv') as f:
    reader = csv.DictReader(f)
    for row in reader:
        cnts[row['label']] = cnts.get(row['label'], 0) + 1
for k, v in cnts.items():
    print(k, v)
```
which prints:
```bash
N 82393
Y 15086
```

This is the checksum and `wc` counts on the `secretbench.csv` file that I'm using:
```bash
$ sha256sum secretbench.csv && wc secretbench.csv
70e4f3faa30df37cfcf002cbcdc1c56c55917f2326854e807312dd531f360486  secretbench.csv
  167067  449224 45990860 secretbench.csv
```